### PR TITLE
Object links the object touched the image border will also be cleaned

### DIFF
--- a/skimage/segmentation/_clear_border.py
+++ b/skimage/segmentation/_clear_border.py
@@ -58,9 +58,10 @@ def clear_border(labels, buffer_size=0, bgval=0, in_place=False):
     borders[:, :ext] = True
     borders[:, - ext:] = True
 
-    # Re-label, in case we are dealing with a binary image
-    # and to get consistent labeling
-    labels = label(image, background=0) + 1
+    # Re-label if we are dealing with a binary image
+    # Otherwise keep original lables
+    if np.max(image) == 1: # check if the image is binary
+        labels = label(image)[0] + 1 #Function 'lable' has no parameter 'background', and the output is taple
     number = np.max(labels) + 1
 
     # determine all objects that are connected to borders


### PR DESCRIPTION
Objects touch the objects connected to the image border will also be cleared. 
a = np.array([[0, 0, 0, 1, 0, 0],
                      [0, 2, 2, 0, 3, 0],
                      [0, 0, 0, 0, 0, 0],
                      [4, 5, 5, 0, 0, 0],
                      [0, 0, 0, 6, 6, 0],
                      [0, 0, 0, 7, 0, 0]])
 5 and 6 will be merged with 4 and 7, respectively, after re-label. And will be treated as border-touched objects and cleared. 

Add Line 63 and fixed line 64.
